### PR TITLE
fix: 画像の配置およびはみ出す場合の対応

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -24,13 +24,13 @@ function dateTimetoLocalDateString(date: Date) {
                     // 記事の数だけ表示
                     articles.flatMap((article: Article) => (
                       <article data-pagefind-ignore="all">
-                        <a href={`/articles/${article.slug}/`}>
-                          <img
-                            src={article.thumbnail.url}
-                            alt={`img_${article.title}/`}
-                            class="m-1"
-                          />
-                        </a>
+                          <a href={`/articles/${article.slug}/`}>
+                            <img
+                              src={article.thumbnail.url}
+                              alt={`img_${article.title}/`}
+                              class="m-1 aspect-[5/3] object-cover w-full"
+                            />
+                          </a>
                         <div class="flex flex-wrap">
                         <p class="created-at">{dateTimetoLocalDateString(article.createdAt)}</p>
                         <p class="updated-at">{dateTimetoLocalDateString(article.updatedAt)}</p>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -46,14 +46,17 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
               ))
             }
             </ul>
-          <img
+          <div class="max-h-[350px] overflow-hidden">
+            <img
                 src={article.thumbnail.url}
                 alt={`img_${article.title}/`}
-            />
+              />
+          </div>
         </div>
         <p class="py-5">{article.lead_text}</p>
           <div class="
             [&_h2]:text-xl [&_h2]:font-medium [&_h2]:my-4
+            [&_h3]:text-lg [&_h3]:font-medium [&_h3]:my-3
             [&_blockquote]:border-l-4 
             [&_blockquote]:p-3
             [&_blockquote]:mx-9
@@ -62,6 +65,8 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
             [&_a]:underline
             [&_ul]:pl-6
             [&_li]:list-disc
+            [&_figure]:flex [&_figure]:flex-col [&_figure]:items-center
+            
           " set:html={article.main_text}>
           </div>
           <Related articles={relatedArticles.contents} />


### PR DESCRIPTION
## [Summary]
- サムネイル画像のサイズとクロップを修正
- 記事中画像を中央寄せするよう修正

## [Details]
次のような問題があった
- サムネイル画像が縦に長い場合に記事一覧レイアウトや記事詳細レイアウトが崩れる
- 記事中画像にスタイルが指定されていない
上記対応により修正した
