### PR TITLE
fix: スタイルの修正

### DIFF
--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -22,6 +22,7 @@ const { articles } = Astro.props
     .related h2 {
         font-size: 1.25rem;
         font-weight: medium;
+        margin: 0.5rem 0;
     }
     .related ul {
         list-style: none;

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -44,7 +44,7 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
               ))
             }
             </ul>
-          <div class="max-h-[350px] overflow-hidden">
+          <div class="max-h-[350px] overflow-hidden flex justify-center items-center">
             <img
                 src={article.thumbnail.url}
                 alt={`img_${article.title}/`}
@@ -53,13 +53,13 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
         </div>
         <p class="py-5">{article.lead_text}</p>
           <div class="
-            [&_h2]:text-xl [&_h2]:font-medium [&_h2]:my-4
+            [&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-6
             [&_h3]:text-lg [&_h3]:font-medium [&_h3]:my-3
             [&_blockquote]:border-l-4 
             [&_blockquote]:p-3
             [&_blockquote]:mx-9
             [&_blockquote]:border-blue-500 [&_blockquote]:bg-[#f5f5f5]
-            [&_p]:m-3 [&_p]:text-sm
+            [&_p]:m-3 [&_p]:text-base
             [&_a]:underline
             [&_ul]:pl-6
             [&_li]:list-disc
@@ -146,6 +146,6 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
   .main_text h2 {
     font-size: 1.5rem;
     font-weight: bold;
-    margin: 1rem 0;
+    margin: 2rem 0;
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -56,4 +56,25 @@ body {
     font-size: 14px;
     font-weight: 400;
 }
- 
+
+
+p {
+    margin: 1.5rem 0;
+}
+
+h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 2.0rem 0;
+}
+
+h3 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 1.5rem 0;
+}
+
+.iframely-embed {
+    margin: 1.5rem;
+
+}


### PR DESCRIPTION


    サムネイルの最大幅サイズを制限し、中央揃えにする
    h2タグの余白を大きくし、太字にする
    本文サイズを大きくし、段落タグpの上下の余白を広く取る

