### PR TITLE
fix: 見出し、リストのスタイル修正

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,9 +3,9 @@ import Hamburger from './Hamburger.astro';
 import Navigation from './Navigation.astro';
 ---
 <header class="bg-[#d0d7deb3] w-full flex flex-nowrap">
-    <div class="text-2xl p-4 underline font-medium ml-auto sm:ml-32 mr-auto items-center">
+    <h1 class="underline font-medium ml-auto mr-auto items-center my-3">
         <a href="/">hito-horobe.net</a>
-    </div>
+    </h1>
     <button id="themeToggle">
         <svg width="30px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <path class="sun" fill-rule="evenodd" d="M12 17.5a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm0 1.5a7 7 0 1 0 0-14 7 7 0 0 0 0 14zm12-7a.8.8 0 0 1-.8.8h-2.4a.8.8 0 0 1 0-1.6h2.4a.8.8 0 0 1 .8.8zM4 12a.8.8 0 0 1-.8.8H.8a.8.8 0 0 1 0-1.6h2.5a.8.8 0 0 1 .8.8zm16.5-8.5a.8.8 0 0 1 0 1l-1.8 1.8a.8.8 0 0 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM6.3 17.7a.8.8 0 0 1 0 1l-1.7 1.8a.8.8 0 1 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM12 0a.8.8 0 0 1 .8.8v2.5a.8.8 0 0 1-1.6 0V.8A.8.8 0 0 1 12 0zm0 20a.8.8 0 0 1 .8.8v2.4a.8.8 0 0 1-1.6 0v-2.4a.8.8 0 0 1 .8-.8zM3.5 3.5a.8.8 0 0 1 1 0l1.8 1.8a.8.8 0 1 1-1 1L3.5 4.6a.8.8 0 0 1 0-1zm14.2 14.2a.8.8 0 0 1 1 0l1.8 1.7a.8.8 0 0 1-1 1l-1.8-1.7a.8.8 0 0 1 0-1z"/>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -31,9 +31,9 @@ const { pageTitle, articles, description, image, url } = Astro.props
                         <p class="published-at">{dateTimetoLocalDateString(article.publishedAt)}</p>
                         <p class="updated-at">{dateTimetoLocalDateString(article.updatedAt)}</p>
                         </div>
-                          <h2 class="text-xl font-semibold p-1 m-1">
+                          <h1 class="text-xl font-semibold p-1 m-1">
                             <a href={`/articles/${article.slug}/`}>{article.title}</a>
-                          </h2>
+                          </h1>
                         <p class="p-1 m-1">{article.lead_text}</p>
                         <p class="category">
                           <a href={`/category/${article.category.name}/1`}>{article.category.name}</a>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -31,7 +31,7 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
   <div class="flex-1 mr-4">
   <article class="p-3" data-pagefind-body>
         <div>
-          <h2 class="text-xl font-semibold p-1 m-1 text-center">{article.title}</h2>
+          <h1>{article.title}</h1>
           <ul class="date">
             <li class="published-at">{dateTimetoLocalDateString(article.publishedAt)}</li>
             <li class="updated-at">{dateTimetoLocalDateString(article.updatedAt)}</li>
@@ -54,7 +54,7 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
         <p class="py-5">{article.lead_text}</p>
           <div class="
             [&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-6
-            [&_h3]:text-lg [&_h3]:font-medium [&_h3]:my-3
+            [&_h3]:text-lg [&_h3]:font-bold [&_h3]:my-3
             [&_blockquote]:border-l-4 
             [&_blockquote]:p-3
             [&_blockquote]:mx-9
@@ -129,7 +129,6 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
     list-style: none;
     border-radius: 1rem;
     font-weight: bold;
-    font-size: 0.8rem;
     color: #0969da;
   }
 
@@ -147,5 +146,11 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
     font-size: 1.5rem;
     font-weight: bold;
     margin: 2rem 0;
+  }
+
+  .main_text h3 {
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin: 1.5rem 0;
   }
 </style>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -137,7 +137,9 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
     color: #ffffff;
   }
 
-
+  h1 {
+    text-align: center; 
+  }
 
   .main_text {
     font: 400 14px/20px 'Helvetica Neue', 'Arial', 'sans-serif;'

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -64,8 +64,7 @@ p {
 h1 {
     font-size: 1.75rem;
     font-weight: bold;
-    margin: 2.5rem 0;
-    text-align: center;
+    margin: 2.0rem 0;
 }
 
 h2 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,7 +53,7 @@ html.dark blockquote {
 
 body {
     font-family: "Roboto", "Helvetica Neue", "sans-serif";
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 400;
 }
 
@@ -61,16 +61,22 @@ body {
 p {
     margin: 1.5rem 0;
 }
+h1 {
+    font-size: 1.75rem;
+    font-weight: bold;
+    margin: 2.5rem 0;
+    text-align: center;
+}
 
 h2 {
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: bold;
     margin: 2.0rem 0;
 }
 
 h3 {
     font-size: 1.25rem;
-    font-weight: 700;
+    font-weight: bold;
     margin: 1.5rem 0;
 }
 


### PR DESCRIPTION
## [Summary]
- リストの文字が小さい
- 記事タイトルがh1タグではなくh2タグになっている
- h3タグの文字が太くならない

## [Details]
- グローバルの文字サイズを16pxに設定
- 記事タイトルを個別ページ、一覧ページの両方でh1にする
- h3タグのスタイルの修正