### PR TITLE
fix: 本文中リンクを青色に変更

### DIFF
--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -60,7 +60,7 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
             [&_blockquote]:mx-9
             [&_blockquote]:border-blue-500 [&_blockquote]:bg-[#f5f5f5]
             [&_p]:m-3 [&_p]:text-base
-            [&_a]:underline
+            [&_a]:underline [&_a]:text-blue-600
             [&_ul]:pl-6
             [&_li]:list-disc
             [&_figure]:flex [&_figure]:flex-col [&_figure]:items-center


### PR DESCRIPTION
スタイルを変更
本文中リンクを青にし、リンクであることを明示した（アフィリエイト用のクリック数向上試作）