### PR TITLE
fix: シェアボタンの文字列が折り返されないよう修正

### DIFF
--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -22,6 +22,10 @@ h2 {
     display: grid;
     color: #ffffff;
     grid-template-columns: 1fr 1fr 1fr 1fr;
+    /* 折り返さない */
+    white-space: nowrap
+
+
 
 }
 .share-buttons li {


### PR DESCRIPTION
close https://github.com/hitohorobe/hito-horobe.net/issues/76