### PR TITLE
fix: ページネーションの戻るボタンが効かない問題の修正、文言変更

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -3,9 +3,9 @@ const { page } = Astro.props
 ---
 <div class="pagination">
     <ul>
-        { page.url.prev ? <li class="prev">＜<a href={page.url.prev}></a></li>: null}
+        { page.url.prev ? <li class="prev"><a href={page.url.prev}>前のページ</a></li>: null}
          <li class="currentPage">{page.currentPage}</li>
-        { page.url.next ? <li class="next"><a href={page.url.next}>＞</a></li>: null}
+        { page.url.next ? <li class="next"><a href={page.url.next}>次のページ</a></li>: null}
     </ul>
 </div>
 


### PR DESCRIPTION
- ページネーションの戻るボタンがリンクになっていなかったので戻れなくなっていた
- ＜と＞の記号がわかりにくいため、前のページ、次のページと表記を変更する