### PR TITLE
fix: 本文中リンクを黒から青に変更

### DIFF
--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -62,7 +62,7 @@ const relatedArticles = await getArticles({ limit: 4, fields: ["title", "slug"] 
             [&_blockquote]:mx-9
             [&_blockquote]:border-blue-500 [&_blockquote]:bg-[#f5f5f5]
             [&_p]:m-3 [&_p]:text-base
-            [&_a]:underline
+            [&_a]:underline [&_a]:text-blue-600
             [&_ul]:pl-6
             [&_li]:list-disc
             [&_figure]:flex [&_figure]:flex-col [&_figure]:items-center


### PR DESCRIPTION
https://github.com/hitohorobe/hito-horobe.net/pull/77 と同様
https://github.com/hitohorobe/hito-horobe.net/pull/79 で誤って戻してしまったので再適用する