### PR TITLE
fix: rssのリンクを修正

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -21,7 +21,7 @@ export async function GET(context) {
             // <description>フィールド
             description: article.lead_text,
             // <link>フィールド
-            link: `${context.site}${article.id}`,
+            link: `${context.site}articles/${article.id}`,
             // <pubDate>フィールド
             pubDate: article.publishedAt,
             // (任意) <category>フィールド


### PR DESCRIPTION
RSSの記事リンクが誤っており、RSSからアクセスすると404が返るようになっていたので修正