### PR TITLE
fix: サイドバーを追従させつつ別個にスクロール可能にする

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -60,13 +60,15 @@ const articles = articleApiResponse.contents;
     .sidebar {
         width: 100%;
         position: sticky;
+        overflow-y: scroll;
         top: 1rem;
+        max-height: 90vh;
     }
     .sidebar h3 {
         font-size: 1rem;
         text-align: center;
         font-weight: bold;
-        padding: 0.5rem;
+        margin: 0.75rem;
     }
     .sidebar .article_list {
         margin: 0.5rem;


### PR DESCRIPTION
## [Summary]
- PCから表示する時、サイドバーを追従させている
- 追従でしかサイドバーが動かず、記事を一番下まで下げないとサイドバー下部の内容を表示できない問題があった


## [Details]
- サイドバーの位置にカーソルを合わせてホイールを動かすとスクロールするようにした