### PR TITLE
fix: RSS内のlinkフィールドをarticle.idからarticle.slugに修正する

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -21,7 +21,7 @@ export async function GET(context) {
             // <description>フィールド
             description: article.lead_text,
             // <link>フィールド
-            link: `${context.site}articles/${article.id}`,
+            link: `${context.site}articles/${article.slug}`,
             // <pubDate>フィールド
             pubDate: article.publishedAt,
             // (任意) <category>フィールド


### PR DESCRIPTION
## [Summary]
- RSS内のlinkフィールドをarticle.idからarticle.slugに修正する

## [Details]
- コンテンツIDではなくslugで記事のURLを管理するよう統一したため