### PR TITLE
fix: ブログヘッダのレイアウト崩れの修正

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,19 +2,22 @@
 import Hamburger from './Hamburger.astro';
 import Navigation from './Navigation.astro';
 ---
-<header class="bg-[#d0d7deb3] w-full flex flex-nowrap">
-    <h1 class="underline font-medium ml-auto mr-auto items-center my-3">
-        <a href="/">hito-horobe.net</a>
-    </h1>
-    <button id="themeToggle">
-        <svg width="30px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <path class="sun" fill-rule="evenodd" d="M12 17.5a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm0 1.5a7 7 0 1 0 0-14 7 7 0 0 0 0 14zm12-7a.8.8 0 0 1-.8.8h-2.4a.8.8 0 0 1 0-1.6h2.4a.8.8 0 0 1 .8.8zM4 12a.8.8 0 0 1-.8.8H.8a.8.8 0 0 1 0-1.6h2.5a.8.8 0 0 1 .8.8zm16.5-8.5a.8.8 0 0 1 0 1l-1.8 1.8a.8.8 0 0 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM6.3 17.7a.8.8 0 0 1 0 1l-1.7 1.8a.8.8 0 1 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM12 0a.8.8 0 0 1 .8.8v2.5a.8.8 0 0 1-1.6 0V.8A.8.8 0 0 1 12 0zm0 20a.8.8 0 0 1 .8.8v2.4a.8.8 0 0 1-1.6 0v-2.4a.8.8 0 0 1 .8-.8zM3.5 3.5a.8.8 0 0 1 1 0l1.8 1.8a.8.8 0 1 1-1 1L3.5 4.6a.8.8 0 0 1 0-1zm14.2 14.2a.8.8 0 0 1 1 0l1.8 1.7a.8.8 0 0 1-1 1l-1.8-1.7a.8.8 0 0 1 0-1z"/>
-          <path class="moon" fill-rule="evenodd" d="M16.5 6A10.5 10.5 0 0 1 4.7 16.4 8.5 8.5 0 1 0 16.4 4.7l.1 1.3zm-1.7-2a9 9 0 0 1 .2 2 9 9 0 0 1-11 8.8 9.4 9.4 0 0 1-.8-.3c-.4 0-.8.3-.7.7a10 10 0 0 0 .3.8 10 10 0 0 0 9.2 6 10 10 0 0 0 4-19.2 9.7 9.7 0 0 0-.9-.3c-.3-.1-.7.3-.6.7a9 9 0 0 1 .3.8z"/>
-        </svg>
-      </button>
-    </div>
-    <div class="md:hidden mr-1 flex justify-center items-center">
-        <Hamburger />
+<header class="bg-[#d0d7deb3] w-full">
+    <div class="max-w-[1100px] mx-auto px-3 flex items-center flex-nowrap">
+        <h1 class="underline font-medium my-3">
+            <a href="/">hito-horobe.net</a>
+        </h1>
+        <div class="ml-auto flex items-center gap-2">
+            <button id="themeToggle">
+                <svg width="30px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                  <path class="sun" fill-rule="evenodd" d="M12 17.5a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm0 1.5a7 7 0 1 0 0-14 7 7 0 0 0 0 14zm12-7a.8.8 0 0 1-.8.8h-2.4a.8.8 0 0 1 0-1.6h2.4a.8.8 0 0 1 .8.8zM4 12a.8.8 0 0 1-.8.8H.8a.8.8 0 0 1 0-1.6h2.5a.8.8 0 0 1 .8.8zm16.5-8.5a.8.8 0 0 1 0 1l-1.8 1.8a.8.8 0 0 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM6.3 17.7a.8.8 0 0 1 0 1l-1.7 1.8a.8.8 0 1 1-1-1l1.7-1.8a.8.8 0 0 1 1 0zM12 0a.8.8 0 0 1 .8.8v2.5a.8.8 0 0 1-1.6 0V.8A.8.8 0 0 1 12 0zm0 20a.8.8 0 0 1 .8.8v2.4a.8.8 0 0 1-1.6 0v-2.4a.8.8 0 0 1 .8-.8zM3.5 3.5a.8.8 0 0 1 1 0l1.8 1.8a.8.8 0 1 1-1 1L3.5 4.6a.8.8 0 0 1 0-1zm14.2 14.2a.8.8 0 0 1 1 0l1.8 1.7a.8.8 0 0 1-1 1l-1.8-1.7a.8.8 0 0 1 0-1z"/>
+                  <path class="moon" fill-rule="evenodd" d="M16.5 6A10.5 10.5 0 0 1 4.7 16.4 8.5 8.5 0 1 0 16.4 4.7l.1 1.3zm-1.7-2a9 9 0 0 1 .2 2 9 9 0 0 1-11 8.8 9.4 9.4 0 0 1-.8-.3c-.4 0-.8.3-.7.7a10 10 0 0 0 .3.8 10 10 0 0 0 9.2 6 10 10 0 0 0 4-19.2 9.7 9.7 0 0 0-.9-.3c-.3-.1-.7.3-.6.7a9 9 0 0 1 .3.8z"/>
+                </svg>
+            </button>
+            <div class="md:hidden flex justify-center items-center">
+                <Hamburger />
+            </div>
+        </div>
     </div>
 </header>
 <div class="nav">
@@ -37,7 +40,6 @@ import Navigation from './Navigation.astro';
     #themeToggle {
         border: 0;
         background: none;
-        margin-right: 1rem;
     }
     .sun { fill: black; }
     .moon { fill: transparent; }
@@ -55,18 +57,6 @@ import Navigation from './Navigation.astro';
         .nav.expanded {
             display: none;
         }
-        #themeToggle {
-            border: 0;
-            background: none;
-            margin-left: 0;
-        
-        }
-        .sun { fill: black; }
-        .moon { fill: transparent; }
-
-        :global(.dark) .sun { fill: transparent; }
-        :global(.dark) .moon { fill: white; }
-
     }
 
 </style>


### PR DESCRIPTION
ヘッダが崩れている

<img width="1903" height="927" alt="image" src="https://github.com/user-attachments/assets/a08677d0-60ee-437e-88c4-d3df17d1ed7d" />


このように直す


<img width="1903" height="927" alt="image" src="https://github.com/user-attachments/assets/05e721d3-dc1b-4efb-bfb9-6bc5cd8b37b9" />
