### PR TITLE
feature: リンクを自動で埋め込みに変換する

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,12 @@ CONTENT_REPO_TOKEN=
 # 同期するブランチ名
 CONTENT_REPO_BRANCH=main
 
+# 執筆中プレビュー用(ローカル専用、Netlifyでは設定しない):
+# hito-horobe-articlesのローカル作業コピーへのパスを指定すると、
+# gitクローンの代わりにシンボリックリンクを張り、コミット前の編集内容も
+# そのままdevサーバーで確認できる。設定するとCONTENT_REPO_URLより優先される。
+# CONTENT_LOCAL_PATH=../hito-horobe-articles
+
 # microCMSからのマイグレーション用設定（移行完了後は不要）
 # MICROCMS_SERVICE_DOMAIN=<YOUR_SERVICE_DOMAIN>
 # MICROCMS_API_KEY=<API_KEY>

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 
 # synced articles content repo (scripts/sync-content.mjs)
 content/
+
+# link preview (OGP) fetch cache (src/libs/link-preview.ts)
+.cache/
 # generated types
 .astro/
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,16 @@ https://hito-horobe.net
 
 記事コンテンツは [hito-horobe-articles](https://github.com/hitohorobe/hito-horobe-articles) リポジトリで管理しています。`npm run dev` / `npm run build` の前に自動的にcloneされます(`scripts/sync-content.mjs`、`.env.sample` 参照)。
 
+## 記事執筆中のプレビュー
+
+`hito-horobe-articles` をこのリポジトリと兄弟ディレクトリとしてcloneし、`.env` に以下を設定すると、gitクローンの代わりにローカル作業コピーへシンボリックリンクが張られ、コミット前の編集内容もそのまま `npm run dev` でホットリロード確認できます。
+
+```
+CONTENT_LOCAL_PATH=../hito-horobe-articles
+```
+
+## URL埋め込み(リンクカード)
+
+記事本文中の単独行のURLは、ビルド時にOGP情報を取得してリンクカード表示になります(`src/plugins/remark-link-card.mjs`, `src/components/LinkCard.astro`)。取得結果は `.cache/link-preview/` にキャッシュされ、2回目以降のビルドは高速化されます。
+
 microCMSからの移行ツールは `scripts/migrate-from-microcms/` にあります(`npm run migrate-from-microcms -- --target <path>`)。

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import pagefind from "astro-pagefind";
 import tailwindcss from "@tailwindcss/vite";
 import mdx from "@astrojs/mdx";
 import remarkFigureCaption from "./src/plugins/remark-figure-caption.mjs";
+import remarkLinkCard from "./src/plugins/remark-link-card.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,7 +14,7 @@ export default defineConfig({
   },
   integrations: [pagefind(), mdx()],
   markdown: {
-    remarkPlugins: [remarkFigureCaption],
+    remarkPlugins: [remarkFigureCaption, remarkLinkCard],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.6",
         "astro-pagefind": "^1.8.0",
+        "open-graph-scraper": "^6.12.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^5.8.3",
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
+        "@types/node": "^26.1.1",
         "@types/turndown": "^5.0.5",
         "microcms-js-sdk": "^3.1.2",
         "turndown": "^7.2.0",
@@ -2325,6 +2327,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/turndown": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
@@ -2764,6 +2776,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -3249,6 +3309,31 @@
       "dependencies": {
         "@emmetio/abbreviation": "^2.3.3",
         "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -3974,11 +4059,58 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -5728,6 +5860,21 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/open-graph-scraper": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.12.0.tgz",
+      "integrity": "sha512-x0fS3eHxdCox+rFBhQSVe+qBznSPn1pspp8A4BoaVEkiECZEwagEb8z06swLfaFFE2gefj1BvEBeJmdeGTDnYw==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.2.0",
+        "cheerio": "^1.2.0",
+        "iconv-lite": "^0.7.2",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -5845,6 +5992,31 @@
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6456,6 +6628,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -6835,6 +7013,22 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -7516,6 +7710,40 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which-pm-runs": {

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.6",
     "astro-pagefind": "^1.8.0",
+    "open-graph-scraper": "^6.12.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.8.3",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/turndown": "^5.0.5",
     "microcms-js-sdk": "^3.1.2",
     "turndown": "^7.2.0",
-    "@types/turndown": "^5.0.5",
     "yaml": "^2.7.0"
   }
 }

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // 記事コンテンツリポジトリ(hito-horobe-articles)を content/ に同期する。
 // dev/build の前に自動実行される(package.json の predev/prebuild)。
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 try {
   process.loadEnvFile();
@@ -14,14 +15,8 @@ try {
 const REPO_URL = process.env.CONTENT_REPO_URL;
 const BRANCH = process.env.CONTENT_REPO_BRANCH || "main";
 const TOKEN = process.env.CONTENT_REPO_TOKEN;
+const LOCAL_PATH = process.env.CONTENT_LOCAL_PATH;
 const TARGET_DIR = fileURLToPath(new URL("../content", import.meta.url));
-
-if (!REPO_URL) {
-  console.error(
-    "[sync-content] CONTENT_REPO_URL が設定されていません。.env.sample を参考に .env を用意してください。"
-  );
-  process.exit(1);
-}
 
 function authenticatedUrl(url, token) {
   if (!token || !url.startsWith("https://")) return url;
@@ -32,21 +27,64 @@ function run(args) {
   execFileSync("git", args, { stdio: "inherit" });
 }
 
-if (existsSync(TARGET_DIR)) {
-  console.log(`[sync-content] updating ${TARGET_DIR} (branch: ${BRANCH})`);
-  run(["-C", TARGET_DIR, "fetch", "--depth", "1", "origin", BRANCH]);
-  run(["-C", TARGET_DIR, "reset", "--hard", "FETCH_HEAD"]);
+// 執筆中プレビュー用: CONTENT_LOCAL_PATHが設定されていれば、gitを使わず
+// ローカルの記事リポジトリ作業コピーへシンボリックリンクを張る。
+// コミット前の編集内容もそのままAstro devサーバーで確認できる。
+function syncFromLocalPath() {
+  const resolvedLocal = path.resolve(LOCAL_PATH);
+  if (!existsSync(resolvedLocal)) {
+    console.error(`[sync-content] CONTENT_LOCAL_PATH が見つかりません: ${resolvedLocal}`);
+    process.exit(1);
+  }
+
+  if (existsSync(TARGET_DIR)) {
+    const stat = lstatSync(TARGET_DIR);
+    if (stat.isSymbolicLink() && readlinkSync(TARGET_DIR) === resolvedLocal) {
+      console.log(`[sync-content] already symlinked to ${resolvedLocal}`);
+      return;
+    }
+    rmSync(TARGET_DIR, { recursive: true, force: true });
+  }
+
+  symlinkSync(resolvedLocal, TARGET_DIR, "dir");
+  console.log(`[sync-content] symlinked content -> ${resolvedLocal} (CONTENT_LOCAL_PATH)`);
+}
+
+function syncFromGit() {
+  if (!REPO_URL) {
+    console.error(
+      "[sync-content] CONTENT_REPO_URL または CONTENT_LOCAL_PATH が設定されていません。.env.sample を参考に .env を用意してください。"
+    );
+    process.exit(1);
+  }
+
+  // CONTENT_LOCAL_PATHから通常のgit同期に切り替えた場合、残ったシンボリックリンクを消す
+  if (existsSync(TARGET_DIR) && lstatSync(TARGET_DIR).isSymbolicLink()) {
+    rmSync(TARGET_DIR, { force: true });
+  }
+
+  if (existsSync(TARGET_DIR)) {
+    console.log(`[sync-content] updating ${TARGET_DIR} (branch: ${BRANCH})`);
+    run(["-C", TARGET_DIR, "fetch", "--depth", "1", "origin", BRANCH]);
+    run(["-C", TARGET_DIR, "reset", "--hard", "FETCH_HEAD"]);
+  } else {
+    console.log(`[sync-content] cloning ${REPO_URL} (branch: ${BRANCH})`);
+    run([
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      BRANCH,
+      authenticatedUrl(REPO_URL, TOKEN),
+      TARGET_DIR,
+    ]);
+  }
+}
+
+if (LOCAL_PATH) {
+  syncFromLocalPath();
 } else {
-  console.log(`[sync-content] cloning ${REPO_URL} (branch: ${BRANCH})`);
-  run([
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    BRANCH,
-    authenticatedUrl(REPO_URL, TOKEN),
-    TARGET_DIR,
-  ]);
+  syncFromGit();
 }
 
 console.log("[sync-content] done");

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -1,0 +1,40 @@
+---
+import { getLinkPreview } from "../libs/link-preview";
+
+const { url } = Astro.props;
+const preview = url ? await getLinkPreview(url) : null;
+---
+{
+  preview ? (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="link-card not-italic block my-6 border border-gray-300 rounded-lg overflow-hidden no-underline hover:bg-gray-50 transition-colors"
+    >
+      {preview.image && (
+        <div class="w-full h-48 sm:h-64 md:h-80 overflow-hidden flex items-center justify-center bg-white">
+          <img
+            src={preview.image}
+            alt=""
+            loading="lazy"
+            class="w-full h-full object-contain"
+          />
+        </div>
+      )}
+      <div class={`p-3 ${preview.image ? "border-t border-gray-200" : ""}`}>
+        <p class="!m-0 font-semibold text-gray-900 line-clamp-2">{preview.title}</p>
+        {preview.description && (
+          <p class="!mx-0 !mt-1 !mb-0 text-sm text-gray-500 line-clamp-2">{preview.description}</p>
+        )}
+        {preview.siteName && (
+          <p class="!mx-0 !mt-2 !mb-0 text-xs text-gray-400 truncate">{preview.siteName}</p>
+        )}
+      </div>
+    </a>
+  ) : (
+    <a href={url} target="_blank" rel="noopener noreferrer" class="link-card underline text-blue-600 break-all">
+      {url}
+    </a>
+  )
+}

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -1,37 +1,67 @@
 ---
 import { getLinkPreview } from "../libs/link-preview";
 
-const { url } = Astro.props;
+const { url, variant } = Astro.props;
 const preview = url ? await getLinkPreview(url) : null;
+const isSmall = variant === "small";
 ---
 {
   preview ? (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="link-card not-italic block my-6 border border-gray-300 rounded-lg overflow-hidden no-underline hover:bg-gray-50 transition-colors"
-    >
-      {preview.image && (
-        <div class="w-full h-48 sm:h-64 md:h-80 overflow-hidden flex items-center justify-center bg-white">
-          <img
-            src={preview.image}
-            alt=""
-            loading="lazy"
-            class="w-full h-full object-contain"
-          />
+    isSmall ? (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="link-card not-italic flex items-stretch my-6 border border-gray-300 rounded-lg overflow-hidden no-underline hover:bg-gray-50 transition-colors"
+      >
+        <div class="flex-1 min-w-0 p-3 flex flex-col justify-center">
+          <p class="!m-0 font-semibold text-gray-900 line-clamp-2">{preview.title}</p>
+          {preview.description && (
+            <p class="!mx-0 !mt-1 !mb-0 text-sm text-gray-500 line-clamp-2">{preview.description}</p>
+          )}
+          {preview.siteName && (
+            <p class="!mx-0 !mt-2 !mb-0 text-xs text-gray-400 truncate">{preview.siteName}</p>
+          )}
         </div>
-      )}
-      <div class={`p-3 ${preview.image ? "border-t border-gray-200" : ""}`}>
-        <p class="!m-0 font-semibold text-gray-900 line-clamp-2">{preview.title}</p>
-        {preview.description && (
-          <p class="!mx-0 !mt-1 !mb-0 text-sm text-gray-500 line-clamp-2">{preview.description}</p>
+        {preview.image && (
+          <div class="w-28 sm:w-40 shrink-0">
+            <img
+              src={preview.image}
+              alt=""
+              loading="lazy"
+              class="w-full h-full object-cover"
+            />
+          </div>
         )}
-        {preview.siteName && (
-          <p class="!mx-0 !mt-2 !mb-0 text-xs text-gray-400 truncate">{preview.siteName}</p>
+      </a>
+    ) : (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="link-card not-italic block my-6 border border-gray-300 rounded-lg overflow-hidden no-underline hover:bg-gray-50 transition-colors"
+      >
+        {preview.image && (
+          <div class="w-full h-48 sm:h-64 md:h-80 overflow-hidden flex items-center justify-center bg-white">
+            <img
+              src={preview.image}
+              alt=""
+              loading="lazy"
+              class="w-full h-full object-contain"
+            />
+          </div>
         )}
-      </div>
-    </a>
+        <div class={`p-3 ${preview.image ? "border-t border-gray-200" : ""}`}>
+          <p class="!m-0 font-semibold text-gray-900 line-clamp-2">{preview.title}</p>
+          {preview.description && (
+            <p class="!mx-0 !mt-1 !mb-0 text-sm text-gray-500 line-clamp-2">{preview.description}</p>
+          )}
+          {preview.siteName && (
+            <p class="!mx-0 !mt-2 !mb-0 text-xs text-gray-400 truncate">{preview.siteName}</p>
+          )}
+        </div>
+      </a>
+    )
   ) : (
     <a href={url} target="_blank" rel="noopener noreferrer" class="link-card underline text-blue-600 break-all">
       {url}

--- a/src/libs/link-preview.ts
+++ b/src/libs/link-preview.ts
@@ -1,0 +1,103 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import ogs from "open-graph-scraper";
+
+export type LinkPreview = {
+  url: string;
+  title: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+};
+
+// Astroのビルドパイプライン中では import.meta.url ベースの相対パス解決が
+// (Viteによるバンドル/コピーの影響で) 想定通りにならないため、
+// npm scriptsから実行される前提でprocess.cwd()(プロジェクトルート)を使う。
+const CACHE_DIR = path.join(process.cwd(), ".cache", "link-preview");
+const TIMEOUT_SECONDS = 8;
+
+const cachePathFor = (url: string) => {
+  const hash = createHash("sha256").update(url).digest("hex");
+  return path.join(CACHE_DIR, `${hash}.json`);
+};
+
+// 外部サイトが返すOGP情報は信頼できないため、画像URLとして使う前に
+// 妥当な絶対URLかどうかを検証する(壊れたページが返す不正な値をそのまま
+// <img src>に流し込まない)。
+const isValidImageUrl = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+// AmazonなどはUser-Agentによって返すHTMLを変える(ボット判定)。
+// 通常のUAだとog:imageタグ自体が無いページが返り、open-graph-scraperの
+// フォールバック(ページ内のimgタグを片っ端から拾う)が働いて無関係な
+// ナビゲーション画像等を誤検出してしまう。SNSクローラー向けUAを送ると
+// 実際の商品画像を含む正規のog:imageタグが返るサイトが多いため、まず
+// これで試し、失敗した場合のみ通常UAで再試行する。
+// onlyGetOpenGraphInfo: true でフォールバックscrapingそのものを禁止し、
+// 常に正規タグの値だけを使うようにする(誤画像を拾うリスクを構造的に防ぐ)。
+const BOT_USER_AGENT = "Twitterbot/1.0";
+
+async function fetchOgResult(url: string) {
+  for (const headers of [{ "user-agent": BOT_USER_AGENT }, undefined]) {
+    try {
+      const { error, result } = await ogs({
+        url,
+        timeout: TIMEOUT_SECONDS,
+        onlyGetOpenGraphInfo: true,
+        ...(headers ? { fetchOptions: { headers } } : {}),
+      });
+      if (!error && (result.ogTitle || result.twitterTitle)) {
+        return result;
+      }
+    } catch {
+      // 次の候補(通常UA)で再試行する
+    }
+  }
+  return null;
+}
+
+// URLのOGP情報を取得する。取得できない/失敗した場合はnullを返す(呼び出し側で
+// プレーンリンクにフォールバックさせ、ビルド全体を失敗させない)。
+// ビルドのたびに同じURLへ再アクセスしないよう、結果を.cache/link-preview/に保存する。
+export const getLinkPreview = async (url: string): Promise<LinkPreview | null> => {
+  const cachePath = cachePathFor(url);
+
+  if (existsSync(cachePath)) {
+    try {
+      const cached = JSON.parse(await readFile(cachePath, "utf-8"));
+      return cached;
+    } catch {
+      // 壊れたキャッシュは無視して再取得する
+    }
+  }
+
+  let preview: LinkPreview | null = null;
+  const result = await fetchOgResult(url);
+  if (result) {
+    preview = {
+      url,
+      title: result.ogTitle ?? result.twitterTitle ?? url,
+      description: result.ogDescription ?? result.twitterDescription,
+      image: isValidImageUrl(result.ogImage?.[0]?.url) ? result.ogImage[0].url : undefined,
+      siteName: result.ogSiteName ?? new URL(url).hostname,
+    };
+  }
+
+  try {
+    await mkdir(CACHE_DIR, { recursive: true });
+    await writeFile(cachePath, JSON.stringify(preview));
+  } catch {
+    // キャッシュ書き込み失敗はビルドを止めるほどの問題ではないので無視する
+  }
+
+  return preview;
+};

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -5,6 +5,7 @@ import Navigation from "../../components/Navigation.astro";
 import Related from "../../components/Related.astro";
 import Sharebuttons from '../../components/ShareButtons.astro';
 import DateCategoryTags from "../../components/DateCategoryTags.astro";
+import LinkCard from "../../components/LinkCard.astro";
 import { getArticles, getArticleBySlug } from "../../libs/content"
 import { DOMAIN, SITE_NAME } from "../../const"
 
@@ -26,7 +27,7 @@ const relatedArticles = (await getArticles()).slice(0, 4);
 <BaseLayout
   pageTitle={`${article.title} | ${SITE_NAME}`}
   description={article.leadText}
-  image={article.thumbnail.src}
+  image={`https://${DOMAIN}${article.thumbnail.src.src}`}
   url={`https://${DOMAIN}/articles/${slug}`}
 >
 <container class="max-w-[1100px] mx-auto flex flex-wrap m-3">
@@ -56,13 +57,13 @@ const relatedArticles = (await getArticles()).slice(0, 4);
               [&_blockquote]:mx-9
               [&_blockquote]:border-blue-500 [&_blockquote]:bg-[#f5f5f5]
               [&_p]:mx-3 [&_p]:my-6 [&_p]:text-base
-              [&_a]:underline [&_a]:text-blue-600 [&_a]:break-all
+              [&_a:not(.link-card)]:underline [&_a:not(.link-card)]:text-blue-600 [&_a:not(.link-card)]:break-all
               [&_ul]:my-6
               [&_li]:list-disc
               [&_figure]:flex [&_figure]:flex-col [&_figure]:items-center [&_figure]:max-w-full
               [&_img]:max-w-full"
           >
-            <Content />
+            <Content components={{ LinkCard }} />
           </div>
           <Related articles={relatedArticles} />
           <Sharebuttons

--- a/src/plugins/remark-link-card.mjs
+++ b/src/plugins/remark-link-card.mjs
@@ -1,0 +1,34 @@
+import { visit } from "unist-util-visit";
+
+// 段落がリンク1つだけで構成されている場合(note.comのようにURLを単独行で
+// 貼り付けた場合、または移行済み記事の「ホスト名だけのリンク」)に、
+// <LinkCard url="..." /> に変換する。
+// 画像へのリンク(`[![alt](img)](href)`)はremark-figure-captionに任せるため対象外。
+function containsImage(node) {
+  if (node.type === "image") return true;
+  return (node.children ?? []).some(containsImage);
+}
+
+export default function remarkLinkCard() {
+  return (tree) => {
+    visit(tree, "paragraph", (node, index, parent) => {
+      if (!parent || index === undefined || node.children.length !== 1) {
+        return;
+      }
+
+      const link = node.children[0];
+      if (link.type !== "link" || !link.url || containsImage(link)) {
+        return;
+      }
+
+      parent.children[index] = {
+        type: "mdxJsxFlowElement",
+        name: "LinkCard",
+        attributes: [
+          { type: "mdxJsxAttribute", name: "url", value: link.url },
+        ],
+        children: [],
+      };
+    });
+  };
+}

--- a/src/plugins/remark-link-card.mjs
+++ b/src/plugins/remark-link-card.mjs
@@ -21,12 +21,17 @@ export default function remarkLinkCard() {
         return;
       }
 
+      const attributes = [{ type: "mdxJsxAttribute", name: "url", value: link.url }];
+      // リンクのtitle属性で "small" を指定すると小型カードになる(画像キャプションと同じ仕組み)。
+      // 未指定/それ以外の値の場合はLinkCard側のデフォルト(大型)が使われる。
+      if (link.title?.trim().toLowerCase() === "small") {
+        attributes.push({ type: "mdxJsxAttribute", name: "variant", value: "small" });
+      }
+
       parent.children[index] = {
         type: "mdxJsxFlowElement",
         name: "LinkCard",
-        attributes: [
-          { type: "mdxJsxAttribute", name: "url", value: link.url },
-        ],
+        attributes,
         children: [],
       };
     });

--- a/src/plugins/remark-link-card.mjs
+++ b/src/plugins/remark-link-card.mjs
@@ -21,10 +21,16 @@ export default function remarkLinkCard() {
         return;
       }
 
+      const title = link.title?.trim().toLowerCase();
+      // リンクのtitle属性で "plain" を指定すると、LinkCard化せず通常のテキストリンクのままにする。
+      if (title === "plain") {
+        return;
+      }
+
       const attributes = [{ type: "mdxJsxAttribute", name: "url", value: link.url }];
-      // リンクのtitle属性で "small" を指定すると小型カードになる(画像キャプションと同じ仕組み)。
+      // title属性で "small" を指定すると小型カードになる(画像キャプションと同じ仕組み)。
       // 未指定/それ以外の値の場合はLinkCard側のデフォルト(大型)が使われる。
-      if (link.title?.trim().toLowerCase() === "small") {
+      if (title === "small") {
         attributes.push({ type: "mdxJsxAttribute", name: "variant", value: "small" });
       }
 


### PR DESCRIPTION
## 概要

- 記事をmicroCMSで管理している時にはURLを入力すると自動でリンクカードの埋め込みを行う機能があった
- githubで管理するようにしてから使えなくなっている（ただのurlになっている）

## 対応

- リンクカード埋め込みの機能を実装する
  - remark-link-card プラグインを使う
  - amazonからのogp取得はuser-agentを変更しないと失敗するので対応する
  - スタイルを編集する
  - リンクに`"small"`キーワードを付けると小さいカードを埋め込むようにする
  - リンクに`"plain"`キーワードを付けるとカード化しない