### PR TITLE
fix: リンクカードの呼び出し頻度を抑えて描画失敗を防ぐ修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "astro check && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
-    "migrate-from-microcms": "node scripts/migrate-from-microcms/index.mjs"
+    "migrate-from-microcms": "node scripts/migrate-from-microcms/index.mjs",
+    "fix-amazon-affiliate-links": "node scripts/fix-amazon-affiliate-links.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.2",

--- a/src/libs/link-preview.ts
+++ b/src/libs/link-preview.ts
@@ -17,11 +17,42 @@ export type LinkPreview = {
 // npm scriptsから実行される前提でprocess.cwd()(プロジェクトルート)を使う。
 const CACHE_DIR = path.join(process.cwd(), ".cache", "link-preview");
 const TIMEOUT_SECONDS = 8;
+const RETRY_DELAY_MS = 1500;
 
 const cachePathFor = (url: string) => {
   const hash = createHash("sha256").update(url).digest("hex");
   return path.join(CACHE_DIR, `${hash}.json`);
 };
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Astroのビルドは複数ページをある程度並行してレンダリングするため、
+// スロットリング無しではAmazon等への同時アクセスが集中し、ボット判定による
+// レート制限/一時ブロックを招きやすい。ビルド全体を通してOGP取得の同時実行数を
+// 制限するための簡易セマフォ。
+const MAX_CONCURRENT_FETCHES = 3;
+let activeFetches = 0;
+const waiters: (() => void)[] = [];
+
+function acquireSlot(): Promise<void> {
+  return new Promise((resolve) => {
+    const tryAcquire = () => {
+      if (activeFetches < MAX_CONCURRENT_FETCHES) {
+        activeFetches++;
+        resolve();
+      } else {
+        waiters.push(tryAcquire);
+      }
+    };
+    tryAcquire();
+  });
+}
+
+function releaseSlot() {
+  activeFetches--;
+  const next = waiters.shift();
+  if (next) next();
+}
 
 // 外部サイトが返すOGP情報は信頼できないため、画像URLとして使う前に
 // 妥当な絶対URLかどうかを検証する(壊れたページが返す不正な値をそのまま
@@ -46,7 +77,7 @@ const isValidImageUrl = (value: unknown): value is string => {
 // 常に正規タグの値だけを使うようにする(誤画像を拾うリスクを構造的に防ぐ)。
 const BOT_USER_AGENT = "Twitterbot/1.0";
 
-async function fetchOgResult(url: string) {
+async function tryFetchOnce(url: string) {
   for (const headers of [{ "user-agent": BOT_USER_AGENT }, undefined]) {
     try {
       const { error, result } = await ogs({
@@ -65,9 +96,19 @@ async function fetchOgResult(url: string) {
   return null;
 }
 
+// レート制限等の一時的な失敗は短時間で解消することが多いため、
+// 両UAとも失敗した場合は間隔を空けてもう一度だけ試す。
+async function fetchOgResult(url: string) {
+  const first = await tryFetchOnce(url);
+  if (first) return first;
+  await sleep(RETRY_DELAY_MS);
+  return tryFetchOnce(url);
+}
+
 // URLのOGP情報を取得する。取得できない/失敗した場合はnullを返す(呼び出し側で
 // プレーンリンクにフォールバックさせ、ビルド全体を失敗させない)。
-// ビルドのたびに同じURLへ再アクセスしないよう、結果を.cache/link-preview/に保存する。
+// ビルドのたびに同じURLへ再アクセスしないよう、成功結果は.cache/link-preview/に保存する
+// (一時的な失敗を将来のビルドに引きずらないよう、失敗時はキャッシュに書き込まない)。
 export const getLinkPreview = async (url: string): Promise<LinkPreview | null> => {
   const cachePath = cachePathFor(url);
 
@@ -80,17 +121,25 @@ export const getLinkPreview = async (url: string): Promise<LinkPreview | null> =
     }
   }
 
-  let preview: LinkPreview | null = null;
-  const result = await fetchOgResult(url);
-  if (result) {
-    preview = {
-      url,
-      title: result.ogTitle ?? result.twitterTitle ?? url,
-      description: result.ogDescription ?? result.twitterDescription,
-      image: isValidImageUrl(result.ogImage?.[0]?.url) ? result.ogImage[0].url : undefined,
-      siteName: result.ogSiteName ?? new URL(url).hostname,
-    };
+  await acquireSlot();
+  let result;
+  try {
+    result = await fetchOgResult(url);
+  } finally {
+    releaseSlot();
   }
+
+  if (!result) {
+    return null;
+  }
+
+  const preview: LinkPreview = {
+    url,
+    title: result.ogTitle ?? result.twitterTitle ?? url,
+    description: result.ogDescription ?? result.twitterDescription,
+    image: isValidImageUrl(result.ogImage?.[0]?.url) ? result.ogImage[0].url : undefined,
+    siteName: result.ogSiteName ?? new URL(url).hostname,
+  };
 
   try {
     await mkdir(CACHE_DIR, { recursive: true });


### PR DESCRIPTION
## 症状

- リンクカードが描画されないことがある

## 原因

- Amazonへのアクセスが連続してしまいogpが返されないことが起こる

## 対応

- ogp取得の同時実行数を制限
- 時間を空けてリトライする
- 取得成功時だけビルドキャッシュに保存して失敗時のキャッシュを次回に引き継がない

